### PR TITLE
Add a python script for diffing FCC directory changes.

### DIFF
--- a/fccdiff.py
+++ b/fccdiff.py
@@ -1,0 +1,63 @@
+import json
+
+def calc_diff(old_path, new_path):
+  """Calculates the difference between two versions of FCC directories.
+
+  Args:
+    old_path: str. The path to the old directory JSON file.
+    new_path: str. The path to the new directory JSON file.
+  Returns:
+    tuple. (removed, added, property_changes). Where 'removed' is a set of the
+    names of people who were removed, 'added' is a set of the names of people
+    who were added, and property_changes is a list of tuples in the following
+    format:
+      (name, "changed|removed|added", key, old_value, new_value)
+  """
+  with open(old_path) as old:
+    old_data = json.load(old)
+  with open(new_path) as new:
+    new_data = json.load(new)
+
+  old_by_name = dict((o['name'], o) for o in old_data)
+  new_by_name = dict((n['name'], n) for n in new_data)
+
+  old_set = set(old_by_name.keys())
+  new_set = set(new_by_name.keys())
+
+  removed = old_set - new_set
+  added = new_set - old_set
+
+  property_changes = []
+  for o_name in old_set:
+    if o_name in new_by_name:
+      o = old_by_name[o_name]
+      n = new_by_name[o_name]
+      matching_keys = n.keys()
+      for key, value in o.items():
+        if n[key] != o[key]:
+          property_changes.append((o_name, 'changed', key, o[key], n[key]))
+        if key in matching_keys:
+          matching_keys.remove(key)
+        else:
+          property_changes.append((o_name, 'removed', key, o[key], ''))
+      for key in matching_keys:
+        property_changes.append((o_name, 'added', key, '', n[key]))
+
+  return removed, added, property_changes
+
+def sentences_from_diff(diff):
+  ans = []
+  removed, added, property_changes = diff
+  for r in removed:
+    ans.append('%s was removed.' % r)
+  for a in added:
+    ans.append('%s was added.' % a)
+  for name, action, key, old, new in property_changes:
+    ans.append(
+      '%s had their \'%s\' changed from %s to %s' % (name, key, old, new))
+  return ans
+
+if __name__ == '__main__':
+  diff = calc_diff('fcc_directory.old.json', 'fcc_directory.json')
+  print repr(diff)
+  print '\n'.join(sentences_from_diff(diff))


### PR DESCRIPTION
Also prints changes in human readable format.

If you save the "old" version as fcc_directory.old.json, this will work out of the box and produce output like:

```
(set([u'Gold Chelsea', u'Ranganathan Vadivelan']), set([u'Ferrufino Anthony']), [(u'Collins Matthew', 'changed', u'phone', u'(202) 418-2738', u'(202) 418-7141'), (u'Collins Matthew', 'changed', u'office', u'WTB', u'OGC'), (u'Collins Matthew', 'changed', u'email', u'M@thew.Collins@fcc.gov', u'M@thewA.Collins@fcc.gov'), (u'Mollison Shona', 'changed', u'phone', u'(202) 418-2120', u'(202) 418-7348')])

Gold Chelsea was removed.
Ranganathan Vadivelan was removed.
Ferrufino Anthony was added.
Collins Matthew had their 'phone' changed from (202) 418-2738 to (202) 418-7141
Collins Matthew had their 'office' changed from WTB to OGC
Collins Matthew had their 'email' changed from M@thew.Collins@fcc.gov to M@thewA.Collins@fcc.gov
Mollison Shona had their 'phone' changed from (202) 418-2120 to (202) 418-7348
```
